### PR TITLE
Disable shellcheck in the main test run

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-all: test shellcheck
+all: test
 
 test:
 	./run_tests.sh


### PR DESCRIPTION
Shellcheck is throwing "SC2039: In POSIX sh, 'local' is undefined"
errors. It's true that local is not a POSIX thing but I am under the
impression all modern sh implementations implement it so it's safe to
use. Shellcheck wasn't throwing this error previously -- I'm not sure if
something changed, or perhaps I had it misconfigured and it's working
correctly now. Disabling until I can figure it out.