### PR TITLE
Fixes to _format_json for msysgit

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ BSD licensed.
 
 ## Setup
 
-Authentication credentials are read from a `~/.netrc` file.
+Authentication credentials are read from a `$HOME/.netrc` file on UNIX
+machines or a `_netrc` file in `%HOME%` for UNIX environments under Windows.
 [Generate the token on GitHub](https://github.com/settings/tokens) under
 "Account Settings -> Applications".
 Restrict permissions on that file with `chmod 600 ~/.netrc`!
@@ -83,6 +84,7 @@ Flags _must_ be the first argument to `ok.sh`, before `command`.
 * [_all_funcs](#_all_funcs)
 * [_log](#_log)
 * [_helptext](#_helptext)
+* [_awk_map](#_awk_map)
 * [_format_json](#_format_json)
 * [_format_urlencode](#_format_urlencode)
 * [_filter_json](#_filter_json)
@@ -176,6 +178,16 @@ Input
 
 * (stdin)
   The text of a function body to parse.
+
+### _awk_map
+
+Invoke awk with a function that will empty the ENVIRON map
+
+Positional arguments
+
+* prg : `$1`
+
+The body of an awk program to run
 
 ### _format_json
 

--- a/ok.sh
+++ b/ok.sh
@@ -381,12 +381,13 @@ _format_json() {
 
     _log debug "Formatting ${#} parameters as JSON."
 
-    env -i "$@" "$awk_bin" '
+    _awk_map '
     function isnum(x){ return (x == x + 0) }
     function isbool(x){ if (x == "true" || x == "false") return 1 }
+
     BEGIN {
-        delete ENVIRON["AWKPATH"]       # GNU addition.
-        delete ENVIRON["AWKLIBPATH"]
+        clear_envrion()
+
         printf("{")
 
         for (name in ENVIRON) {
@@ -405,7 +406,7 @@ _format_json() {
 
         printf("}\n")
     }
-    ' | _filter_json
+    ' "$@" | _filter_json
 }
 
 _format_urlencode() {
@@ -425,7 +426,7 @@ _format_urlencode() {
 
     _log debug "Formatting ${#} parameters as urlencoded"
 
-    env -i "$@" "$awk_bin" '
+    _awk_map '
     function escape(str, c, len, res) {
         len = length(str)
         res = ""
@@ -440,10 +441,10 @@ _format_urlencode() {
     }
 
     BEGIN {
+        clear_envrion()
+
         for (i = 0; i <= 255; i += 1) ord[sprintf("%c", i)] = i;
 
-        delete ENVIRON["AWKPATH"]       # GNU addition.
-        delete ENVIRON["AWKLIBPATH"]
         for (name in ENVIRON) {
             if (substr(name, 1, 1) == "_") continue
             val = ENVIRON[name]
@@ -452,7 +453,7 @@ _format_urlencode() {
             sep = "&"
         }
     }
-    '
+    ' "$@"
 }
 
 _filter_json() {

--- a/ok.sh
+++ b/ok.sh
@@ -17,7 +17,8 @@
 #
 # ## Setup
 #
-# Authentication credentials are read from a `~/.netrc` file.
+# Authentication credentials are read from a `$HOME/.netrc` file on UNIX
+# machines or a `_netrc` file in `%HOME%` for UNIX environments under Windows.
 # [Generate the token on GitHub](https://github.com/settings/tokens) under
 # "Account Settings -> Applications".
 # Restrict permissions on that file with `chmod 600 ~/.netrc`!


### PR DESCRIPTION
It seems `env` on msysgit does not start with an empty environment. E.g., `env -i $(which env)`.