### PR TITLE
Remove Debian repo (and shellcheck) to see if it fixes Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,8 @@ script: |
 
 addons:
   apt:
-    sources:
-    - debian-sid    # Grab shellcheck from the Debian repo (o_O)
     packages:
     - socat
-    - shellcheck
 
 notifications:
   email: false


### PR DESCRIPTION
Reaching across distros was weird and we had disabled shellcheck from
the automated tests anyway due to an odd change in failures (3bbe35e).