### PR TITLE
Fix issues with bad URL parsing because of spaces in header on MacOSX

### DIFF
--- a/ok.sh
+++ b/ok.sh
@@ -779,7 +779,7 @@ status_text: ${status_text}
                 BEGIN { RS=", "; FS="; "; OFS=": " }
                 {
                     sub(/^rel="/, "", $2); sub(/"$/, "", $2)
-                    sub(/^</, "", $1); sub(/>$/, "", $1)
+                    sub(/^[[:space:]]*</, "", $1); sub(/>$/, "", $1)
                     print "Link_" $2, $1
                 }')
 "  # need trailing newline


### PR DESCRIPTION
On my Mac, there is whitespace in the some link headers, E.g. 

`Link_Next:  <https://...>` 

As a result, awk doesn't strip the leading < and things explode. This fix 'works on my machine' and hopefully is generally safe. Please consider merging if it doesn't break anything for anyone else.