### PR TITLE
feat: make download of assets possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Flags _must_ be the first argument to `ok.sh`, before `command`.
 * [create_release](#create_release)
 * [delete_release](#delete_release)
 * [release_assets](#release_assets)
+* [download_asset](#download_asset)
 * [upload_asset](#upload_asset)
 * [list_milestones](#list_milestones)
 * [create_milestone](#create_milestone)
@@ -1034,6 +1035,26 @@ Keyword arguments
 * `_filter='.[] | "\(.id)\t\(.name)\t\(.updated_at)"'`
 
   A jq filter to apply to the return data.
+
+### download_asset
+
+Download a release asset
+
+Usage:
+
+    download_asset user repo 48298
+
+Positional arguments
+
+* `owner="$1"`
+
+  A GitHub user or organization.
+* `repo="$2"`
+
+  A GitHub repository.
+* `asset_id="$3"`
+
+  The unique ID of the asset; see release_assets.
 
 ### upload_asset
 


### PR DESCRIPTION
This time, something larger from me... 😉 I'd like to have the ability to download assets by their asset id. To do so, it is necessary to change the `Accept` header in the corresponding GET request and also follow redirects using the `-L` flag in curl.

Please check whether the way I implemented both comes up to your expectations. :) 
I tried to make the `Accept` header customizable, yet respecting the default `${OK_SH_ACCEPT}`. The parameter must then be routed through `_get` to `_request`.
The `-L` curl flag is hard coded as IMHO it will have no impact on the rest of the functionality (at least, it didn't during my tests 😊).