### PR TITLE
Add support to upload_asset for .apk files

### DIFF
--- a/ok.sh
+++ b/ok.sh
@@ -544,6 +544,7 @@ _get_mime_type() {
         *.tar) mime_type=application/x-tar ;;
         *.txt) mime_type=text/plain ;;
         *.yaml) mime_type=application/x-yaml ;;
+        *.apk) mime_type=application/vnd.android.package-archive ;;
         *.zip) mime_type=application/zip ;;
     esac
 


### PR DESCRIPTION
* This PR adds support to [upload_asset](https://github.com/whiteinge/ok.sh#upload_asset) for `.apk` files. Previously uploading an asset file with `.apk` format leads to failure with error message `The MIME type could not be guessed.`
* It has been tested on macOS and it was working properly.

Resource: This [list](https://www.freeformatter.com/mime-types-list.html) shows the used MIME type