### PR TITLE
Handle "100 Continue" HTTP response in _response

### DIFF
--- a/ok.sh
+++ b/ok.sh
@@ -757,33 +757,30 @@ _response() {
     local hdr
     local val
     local http_version
-    local status_code
+    local status_code=100
     local status_text
     local headers output
 
     _log debug 'Processing response.'
 
-    read -r http_version status_code status_text
-    status_text="${status_text%${crlf}}"
-    http_version="${http_version#HTTP/}"
-
-    _log debug "Response status is: ${status_code} ${status_text}"
-
-    if [ "${status_code}" = "100" ]; then
-        _log debug "Ignoring response '${status_code} ${status_text}', skipping to real response."
-        while IFS=": " read -r hdr val; do
-            # Headers stop at the first blank line.
-            [ "$hdr" = "$crlf" ] && break
-            val="${val%${crlf}}"
-            _log debug "Unexpected additional header: ${hdr}: ${val}"
-        done
-
+    while [ "${status_code}" = "100" ]; do
         read -r http_version status_code status_text
         status_text="${status_text%${crlf}}"
         http_version="${http_version#HTTP/}"
 
         _log debug "Response status is: ${status_code} ${status_text}"
-    fi
+
+        if [ "${status_code}" = "100" ]; then
+            _log debug "Ignoring response '${status_code} ${status_text}', skipping to real response."
+            while IFS=": " read -r hdr val; do
+                # Headers stop at the first blank line.
+                [ "$hdr" = "$crlf" ] && break
+                val="${val%${crlf}}"
+                _log debug "Unexpected additional header: ${hdr}: ${val}"
+            done
+
+        fi
+    done
 
     headers="http_version: ${http_version}
 status_code: ${status_code}

--- a/ok.sh
+++ b/ok.sh
@@ -769,6 +769,22 @@ _response() {
 
     _log debug "Response status is: ${status_code} ${status_text}"
 
+    if [ "${status_code}" = "100" ]; then
+        _log debug "Ignoring response '${status_code} ${status_text}', skipping to real response."
+        while IFS=": " read -r hdr val; do
+            # Headers stop at the first blank line.
+            [ "$hdr" = "$crlf" ] && break
+            val="${val%${crlf}}"
+            _log debug "Unexpected additional header: ${hdr}: ${val}"
+        done
+
+        read -r http_version status_code status_text
+        status_text="${status_text%${crlf}}"
+        http_version="${http_version#HTTP/}"
+
+        _log debug "Response status is: ${status_code} ${status_text}"
+    fi
+
     headers="http_version: ${http_version}
 status_code: ${status_code}
 status_text: ${status_text}

--- a/tests/unit.sh
+++ b/tests/unit.sh
@@ -166,4 +166,24 @@ Hi\n' | $SCRIPT _response Baz Bad Foo | {
     }
 }
 
+test_response_headers_100_continue() {
+    # Test that process response 100 Continue is handled correctly.
+
+    local baz bar foo
+
+    printf 'HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\nServer: example.com\r\nFoo: Foo!\r\nBar: Bar!\r\nBaz: Baz!\r\n\r\nHi
+' | $SCRIPT _response Baz Bad Foo | {
+        read -r baz
+        read -r bar     # Ensure unfound items are blank.
+        read -r foo
+
+        ret=0
+        [ "$baz" = 'Baz!' ] || { ret=1; printf '`Baz!` != `%s`\n' "$baz"; }
+        [ "$bar" = '' ] || { ret=1; printf '`` != `%s`\n' "$bar"; }
+        [ "$foo" = 'Foo!' ] || { ret=1; printf '`Foo!` != `%s`\n' "$foo"; }
+
+        return $ret
+    }
+}
+
 _main "$@"

--- a/tests/unit.sh
+++ b/tests/unit.sh
@@ -171,8 +171,10 @@ test_response_headers_100_continue() {
 
     local baz bar foo
 
-    printf 'HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\nServer: example.com\r\nFoo: Foo!\r\nBar: Bar!\r\nBaz: Baz!\r\n\r\nHi
-' | $SCRIPT _response Baz Bad Foo | {
+    header_100='HTTP/1.1 100 Continue\r\n\r\n'
+    header_200='HTTP/1.1 200 OK\r\n'
+    header_key_value='Server: example.com\r\nFoo: Foo!\r\nBar: Bar!\r\nBaz: Baz!\r\n\r\nHi\n'
+    printf "${header_100}${header_100}${header_200}${header_key_value}" | $SCRIPT _response Baz Bad Foo | {
         read -r baz
         read -r bar     # Ensure unfound items are blank.
         read -r foo


### PR DESCRIPTION
This is a fix for issue #92 based on the proposal by @fzs.
This one also handles multiple 100 responses.
Even though we haven't seen them in the wild, it actually makes the code shorter :)

