### PR TITLE
ignore shellcheck items that do not matter

### DIFF
--- a/ok.sh
+++ b/ok.sh
@@ -403,8 +403,11 @@ _format_json() {
     function isnum(x){ return (x == x + 0) }
     function isnull(x){ return (x == "null" ) }
     function isbool(x){ if (x == "true" || x == "false") return 1 }
-    function isnested(x) { if (substr(x, 0, 1) == "[" \
-        || substr(x, 0, 1) == "{") return 1 }
+    function isnested(x) {
+      if (substr(x, 0, 1) == "[" || substr(x, 0, 1) == "{") {
+        return 1
+      }
+    }
     function castOrQuote(val) {
         if (!isbool(val) && !isnum(val) && !isnull(val) && !isnested(val)) {
             sub(/^('\''|")/, "", val) # Remove surrounding quotes
@@ -509,8 +512,7 @@ _filter_json() {
         return
     fi
 
-    "${OK_SH_JQ_BIN}" -c -r "${_filter}"
-    [ $? -eq 0 ] || printf 'jq parse error; invalid JSON.\n' 1>&2
+    "${OK_SH_JQ_BIN}" -c -r "${_filter}" || printf 'jq parse error; invalid JSON.\n' 1>&2
 }
 
 _get_mime_type() {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,4 +4,4 @@ test:
 	./run_tests.sh
 
 shellcheck:
-	shellcheck -e SC2155 ../ok.sh
+	shellcheck -e SC2155 -e SC2039 -e SC2220 ../ok.sh


### PR DESCRIPTION
There's some shellcheck items that crop up when I edit files. I'm wondering if we can silence the warnings if they do not matter and/or quickly fix the ones that do.