### PR TITLE
fix: make header processing case-insensitive

### DIFF
--- a/ok.sh
+++ b/ok.sh
@@ -799,22 +799,25 @@ status_text: ${status_text}
         [ "$hdr" = "$crlf" ] && break
         val="${val%${crlf}}"
 
+        # Headers are case insensitive
+        hdr="$(printf '%s' "$hdr" | awk '{print toupper($0)}')"
+
         # Process each header; reformat some to work better with sh tools.
         case "$hdr" in
             # Update the GitHub rate limit trackers.
-            X-RateLimit-Remaining)
+            X-RATELIMIT-REMAINING)
                 printf 'GitHub remaining requests: %s\n' "$val" 1>&$LSUMMARY ;;
-            X-RateLimit-Reset)
+            X-RATELIMIT-RESET)
                 awk -v gh_reset="$val" 'BEGIN {
                     srand(); curtime = srand()
                     print "GitHub seconds to reset: " gh_reset - curtime
                 }' 1>&$LSUMMARY ;;
 
             # Remove quotes from the etag header.
-            ETag) val="${val#\"}"; val="${val%\"}" ;;
+            ETAG) val="${val#\"}"; val="${val%\"}" ;;
 
             # Split the URLs in the Link header into separate pseudo-headers.
-            Link) headers="${headers}$(printf '%s' "$val" | awk '
+            LINK) headers="${headers}$(printf '%s' "$val" | awk '
                 BEGIN { RS=", "; FS="; "; OFS=": " }
                 {
                     sub(/^rel="/, "", $2); sub(/"$/, "", $2)


### PR DESCRIPTION
HTTP Headers are [case-insensitive](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2). `ok.sh` matches GitHub's capital / lower case letters exactly right now. This causes problems when the capitalization changes. E.g., I ran into the following issue:
```
curl -sI https://api.github.com/users/whiteinge/starred
```
returns the following on an M1 Mac with default setup (`zsh` and pre-installed `curl`):
```
HTTP/2 200
server: GitHub.com
date: Thu, 05 Aug 2021 18:46:26 GMT
content-type: application/json; charset=utf-8
cache-control: public, max-age=60, s-maxage=60
vary: Accept, Accept-Encoding, Accept, X-Requested-With
etag: W/"83b017ab0e41658bb75b376aa1cb417fb7ea9bfb0df8babe62f4cbb83e9ce2ef"
x-github-media-type: github.v3; format=json
link: <https://api.github.com/user/91293/starred?page=2>; rel="next", <https://api.github.com/user/91293/starred?page=11>; rel="last"
access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
access-control-allow-origin: *
strict-transport-security: max-age=31536000; includeSubdomains; preload
x-frame-options: deny
x-content-type-options: nosniff
x-xss-protection: 0
referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
content-security-policy: default-src 'none'
x-ratelimit-limit: 60
x-ratelimit-remaining: 58
x-ratelimit-reset: 1628191225
x-ratelimit-resource: core
x-ratelimit-used: 2
accept-ranges: bytes
x-github-request-id: DE01:DBE4:1CC9C51:1D5F898:610C3201
```

Since `ok.sh` matches on `Link` for pagination the follow link implementation will not work. This PR converts the header names to all caps to address the case-insensitivity.